### PR TITLE
fix: app navigation bar is squeezed when there is a native navigation bar.

### DIFF
--- a/app/src/main/java/com/lcq/composewechat/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/java/com/lcq/composewechat/ui/screen/home/HomeScreen.kt
@@ -143,7 +143,7 @@ fun HomeScreen() {
                     exit = fadeOut(),
                 ) {
                     NavigationBar(
-                        modifier = Modifier.height(60.dp),
+                        modifier = Modifier.heightIn(60.dp),
                         containerColor = Color(
                             ContextCompat.getColor(
                                 context,


### PR DESCRIPTION
showcase:
<img src="https://github.com/ChaoqinLiu/ComposeWechat/assets/27652454/99202025-9c86-416e-bee0-92792f4efc0f" width=30%>